### PR TITLE
Add mutable config option

### DIFF
--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -17,9 +17,10 @@ let
     # Can't do types.either with multiple non-overlapping submodules, so define our own
     singleLdapValueType = lib.mkOptionType rec {
       name = "LDAP";
-      # TODO: It might be worth defining a { creds = ...; } option, leveraging
+      # TODO: It might be worth defining a { secret = ...; } option, leveraging
       # systemd's LoadCredentials for secrets. That should remove the last
-      # barrier to using DynamicUser for openldap.
+      # barrier to using DynamicUser for openldap. However, this is blocked on
+      # $CREDENTIALS_DIRECTORY being available in ExecStartPre.
       description = ''
         LDAP value - either a string, or an attrset containing `path` or
         `base64`, for included values or base-64 encoded values respectively.
@@ -300,7 +301,6 @@ in {
         ];
         StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
         StateDirectoryMode = "700";
-        # TODO: Patch openldap to put the ldapi:/// socket here
         RuntimeDirectory = "openldap";
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -300,6 +300,7 @@ in {
         ];
         StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
         StateDirectoryMode = "700";
+        # TODO: Patch openldap to put the ldapi:/// socket here
         RuntimeDirectory = "openldap";
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
         CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -220,10 +220,7 @@ in {
   meta.maintainers = with lib.maintainers; [ mic92 kwohlfahrt ];
 
   config = mkIf cfg.enable {
-    assertions = map (opt: {
-      assertion = ((getAttr opt cfg) != "_mkMergedOptionModule") -> (cfg.database != "_mkMergedOptionModule");
-      message = "Legacy OpenLDAP option `services.openldap.${opt}` requires `services.openldap.database` (use value \"mdb\" if unsure)";
-    }) legacyOptions ++ map (dn: {
+    assertions = map (dn: {
       assertion = dataDirs ? "${dn}";
       message = ''
         declarative DB ${dn} does not exist in "servies.openldap.settings" or it exists but the "olcDbDirectory"

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -236,16 +236,21 @@ in {
   meta.maintainers = with lib.maintainers; [ mic92 kwohlfahrt ];
 
   config = mkIf cfg.enable {
-    assertions = (map (dn: {
+    assertions = [{
+      assertion = (cfg.configDir != null) -> declarativeDNs == [];
+      message = ''
+        Declarative DB contents (${dn}) are not supported with user-managed configuration directory".
+      '';
+    }] ++ (map (dn: {
       assertion = dataDirs ? "${dn}";
       message = ''
-        declarative DB ${dn} does not exist in "services.openldap.settings" or it exists but the "olcDbDirectory"
+        Declarative DB ${dn} does not exist in "services.openldap.settings" or it exists but the "olcDbDirectory"
         is not prefixed by "/var/lib/openldap/"
       '';
     }) declarativeDNs) ++ (map (dir: {
       assertion = !(hasPrefix "slapd.d" dir);
       message = ''
-        database path may not be "/var/lib/openldap/slapd.d", this path is used for configuration.
+        Database path may not be "/var/lib/openldap/slapd.d", this path is used for configuration.
       '';
     }) (attrValues dataDirs));
     environment.systemPackages = [ openldap ];

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -305,7 +305,7 @@ in {
           "${openldap}/libexec/slapd" "-F" configDir
           "-h" (escapeSystemd (lib.concatStringsSep " " cfg.urlList))
         ];
-        StateDirectory = [ "openldap/slapd.d" ] ++ additionalStateDirectories;
+        StateDirectory = lib.optional (cfg.configDir == null) ([ "openldap/slapd.d" ] ++ additionalStateDirectories);
         StateDirectoryMode = "700";
         RuntimeDirectory = "openldap";
         AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -1,7 +1,4 @@
-{ pkgs ? (import ../.. { inherit system; config = { }; })
-, system ? builtins.currentSystem
-, ...
-}:
+import ./make-test-python.nix ({ pkgs, ... }:
 
 let
   dbContents = ''
@@ -13,99 +10,88 @@ let
     objectClass: organizationalUnit
     ou: users
   '';
-  testScript = ''
+  testDbExists = ''
     machine.wait_for_unit("openldap.service")
     machine.succeed(
         'ldapsearch -LLL -D "cn=root,dc=example" -w notapassword -b "dc=example"',
     )
   '';
-in {
-  # New-style configuration
-  current = import ./make-test-python.nix ({ pkgs, ... }: {
-    inherit testScript;
-    name = "openldap";
+  manualConfig = pkgs.writeText "config.ldif" ''
+    dn: cn=config
+    cn: config
+    objectClass: olcGlobal
+    olcLogLevel: stats
+    olcPidFile: /run/openldap/slapd.pid
 
-    machine = { pkgs, ... }: {
-      environment.etc."openldap/root_password".text = "notapassword";
-      services.openldap = {
-        enable = true;
-        settings = {
-          children = {
-            "cn=schema".includes = [
-              "${pkgs.openldap}/etc/schema/core.ldif"
-              "${pkgs.openldap}/etc/schema/cosine.ldif"
-              "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
-              "${pkgs.openldap}/etc/schema/nis.ldif"
-            ];
-            "olcDatabase={1}mdb" = {
-              # This tests string, base64 and path values, as well as lists of string values
-              attrs = {
-                objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
-                olcDatabase = "{1}mdb";
-                olcDbDirectory = "/var/lib/openldap/current";
-                olcSuffix = "dc=example";
-                olcRootDN = {
-                  # cn=root,dc=example
-                  base64 = "Y249cm9vdCxkYz1leGFtcGxl";
-                };
-                olcRootPW = {
-                  path = "/etc/openldap/root_password";
-                };
+    dn: cn=schema,cn=config
+    cn: schema
+    objectClass: olcSchemaConfig
+
+    include: file://${pkgs.openldap}/etc/schema/core.ldif
+    include: file://${pkgs.openldap}/etc/schema/cosine.ldif
+    include: file://${pkgs.openldap}/etc/schema/inetorgperson.ldif
+
+    dn: olcDatabase={1}mdb,cn=config
+    objectClass: olcDatabaseConfig
+    objectClass: olcMdbConfig
+    olcDatabase: {1}mdb
+    olcDbDirectory: /var/db/openldap
+    olcDbIndex: objectClass eq
+    olcSuffix: dc=example
+    olcRootDN: cn=root,dc=example
+    olcRootPW: notapassword
+  '';
+in {
+  name = "openldap";
+
+  machine = { pkgs, ... }: {
+    environment.etc."openldap/root_password".text = "notapassword";
+    services.openldap = {
+      enable = true;
+      settings = {
+        children = {
+          "cn=schema".includes = [
+          "${pkgs.openldap}/etc/schema/core.ldif"
+          "${pkgs.openldap}/etc/schema/cosine.ldif"
+          "${pkgs.openldap}/etc/schema/inetorgperson.ldif"
+          "${pkgs.openldap}/etc/schema/nis.ldif"
+        ];
+        "olcDatabase={1}mdb" = {
+            # This tests string, base64 and path values, as well as lists of string values
+            attrs = {
+              objectClass = [ "olcDatabaseConfig" "olcMdbConfig" ];
+              olcDatabase = "{1}mdb";
+              olcDbDirectory = "/var/lib/openldap/current";
+              olcSuffix = "dc=example";
+              olcRootDN = {
+                # cn=root,dc=example
+                base64 = "Y249cm9vdCxkYz1leGFtcGxl";
+              };
+              olcRootPW = {
+                path = "/etc/openldap/root_password";
               };
             };
           };
         };
-        declarativeContents."dc=example" = dbContents;
       };
+      declarativeContents."dc=example" = dbContents;
     };
-  }) { inherit pkgs system; };
-
-  # Manually managed configDir, for example if dynamic config is essential
-  manualConfigDir = import ./make-test-python.nix ({ pkgs, ... }: {
-    name = "openldap";
-
-    machine = { pkgs, ... }: {
-      services.openldap = {
-        enable = true;
-        configDir = "/var/db/slapd.d";
-      };
+    specialisation.manualConfigDir.configuration = { ... }: {
+      services.openldap.configDir = "/var/db/slapd.d";
     };
+  };
 
-    testScript = let
-      contents = pkgs.writeText "data.ldif" dbContents;
-      config = pkgs.writeText "config.ldif" ''
-        dn: cn=config
-        cn: config
-        objectClass: olcGlobal
-        olcLogLevel: stats
-        olcPidFile: /run/openldap/slapd.pid
+  testScript = { nodes, ... }: let config = nodes.machine.config.system.build.toplevel; in ''
+    ${testDbExists}
 
-        dn: cn=schema,cn=config
-        cn: schema
-        objectClass: olcSchemaConfig
-
-        include: file://${pkgs.openldap}/etc/schema/core.ldif
-        include: file://${pkgs.openldap}/etc/schema/cosine.ldif
-        include: file://${pkgs.openldap}/etc/schema/inetorgperson.ldif
-
-        dn: olcDatabase={1}mdb,cn=config
-        objectClass: olcDatabaseConfig
-        objectClass: olcMdbConfig
-        olcDatabase: {1}mdb
-        olcDbDirectory: /var/db/openldap
-        olcDbIndex: objectClass eq
-        olcSuffix: dc=example
-        olcRootDN: cn=root,dc=example
-        olcRootPW: notapassword
-      '';
-    in ''
+    with subtest("handles manual config dir"):
       machine.succeed(
           "mkdir -p /var/db/slapd.d /var/db/openldap",
-          "slapadd -F /var/db/slapd.d -n0 -l ${config}",
-          "slapadd -F /var/db/slapd.d -n1 -l ${contents}",
+          "slapadd -F /var/db/slapd.d -n0 -l ${manualConfig}",
+          "slapadd -F /var/db/slapd.d -n1 -l ${pkgs.writeText "data.ldif" dbContents}",
           "chown -R openldap:openldap /var/db/slapd.d /var/db/openldap",
-          "systemctl restart openldap",
+          "${config}/specialisation/manualConfigDir/bin/switch-to-configuration test",
       )
-    '' + testScript;
-  }) { inherit system pkgs; };
-}
+      ${testDbExists}
+  '';
+})

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -48,7 +48,7 @@ in {
     environment.etc."openldap/root_password".text = "notapassword";
     services.openldap = {
       enable = true;
-      urlList = [ "ldap:///" ];
+      urlList = [ "ldap:///" "ldapi:///" ];
       settings = {
         children = {
           "cn=schema".includes = [
@@ -92,9 +92,6 @@ in {
       manualConfigDir.configuration = { ... }: {
         services.openldap.configDir = "/var/db/slapd.d";
       };
-      localSocket.configuration = { ... }: {
-        services.openldap.urlList = [ "ldapi:///" ];
-      };
     };
   };
 
@@ -117,9 +114,6 @@ in {
       machine.succeed("ldapmodify -D cn=root,cn=config -w configpassword -f ${changeRootPW}")
       machine.systemctl('restart openldap')
       machine.succeed('ldapsearch -LLL -D "cn=root,dc=example" -w foobar -b "dc=example"')
-
-    #with subtest("local IPC socket works"):
-    #  machine.succeed("${config}/specialisation/localSocket/bin/switch-to-configuration test")
 
     with subtest("handles manual config dir"):
       machine.succeed(

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -89,8 +89,12 @@ in {
       mutableConfig.configuration = { ... }: {
         services.openldap.mutableConfig = true;
       };
-      manualConfigDir.configuration = { ... }: {
-        services.openldap.configDir = "/var/db/slapd.d";
+      manualConfigDir = {
+        inheritParentConfig = false;
+        configuration = { ... }: {
+          services.openldap.enable = true;
+          services.openldap.configDir = "/var/db/slapd.d";
+        };
       };
     };
   };

--- a/nixos/tests/openldap.nix
+++ b/nixos/tests/openldap.nix
@@ -60,8 +60,7 @@ in {
             attrs = {
               objectClass = "olcDatabaseConfig";
               olcDatabase = "{0}config";
-              # FIXME: Clean up this, in case somebody tries to copy it
-              olcAccess = "{0}to * by * manage stop";
+              olcAccess = "{0}to * by dn.exact=uidNumber=0+gidNumber=0,cn=peercred,cn=external,cn=auth manage by * +0 stop";
             };
           };
           "olcDatabase={1}mdb" = {
@@ -111,6 +110,7 @@ in {
       machine.succeed("${config}/specialisation/mutableConfig/bin/switch-to-configuration test")
       machine.succeed('ldapsearch -LLL -D "cn=root,dc=example" -w notapassword -b "dc=example"')
       machine.succeed('ldapmodify -Y EXTERNAL -H ldapi://%2Frun%2Fopenldap%2Fldapi -f ${changeRootPW}')
+      machine.systemctl('restart openldap')
       machine.succeed('ldapsearch -LLL -D "cn=root,dc=example" -w foobar -b "dc=example"')
 
     with subtest("handles manual config dir"):

--- a/pkgs/development/libraries/openldap/default-socket-path.patch
+++ b/pkgs/development/libraries/openldap/default-socket-path.patch
@@ -1,0 +1,13 @@
+diff --git a/include/ldap_defaults.h b/include/ldap_defaults.h
+index 916d6bc66..14e08724a 100644
+--- a/include/ldap_defaults.h
++++ b/include/ldap_defaults.h
+@@ -39,7 +39,7 @@
+ #define LDAP_ENV_PREFIX "LDAP"
+ 
+ /* default ldapi:// socket */
+-#define LDAPI_SOCK LDAP_RUNDIR LDAP_DIRSEP "run" LDAP_DIRSEP "ldapi"
++#define LDAPI_SOCK LDAP_RUNDIR LDAP_DIRSEP "run" LDAP_DIRSEP "openldap" LDAP_DIRSEP "ldapi"
+ 
+ /*
+  * SLAPD DEFINITIONS

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-V7WSVL4V0L9qmrPVFMHAV3ewISMpFTMTSofJRGj49Hs=";
   };
 
+  patches = [ ./default-socket-path.patch ];
+
   # TODO: separate "out" and "bin"
   outputs = [ "out" "dev" "man" "devdoc" ];
 


### PR DESCRIPTION
This mainly adds the option `mutableConfig`, as discussed in NixOS/nixpkgs#141240. I got carried away and did a few other things too:

1. Refactor the tests. They now only use one VM (with specializations) instance, instead of two, speeding things up a bit.
2. Add more test cases (to cover the new `mutableConfig`option).
3. Minor fixes to escape args correctly (necessary for `ldapi:///` sockets with custom path)
4. Split the declarative content scripts into separate `ExecStartPre` lines. This makes it obvious from `systemctl status` which part has failed.

I added one additional assertion, that means declarative database contents are not usable with the `configDir` option (which essentially bypasses all of this module). I don't think this check is technically 100% necessary, since if the custom `configDir` contains the right `olcDbDirectory` it should work, but it's easy to get wrong and I don't see much of a use case for using NixOS for database contents, but not config.

I'm also a little cautious about the other assertion (`assertion = dataDirs ? "${dn}";`) - when we have `mutableConfig = true`, this assertion might pass, even though the actual configuration has diverged from what is in `settings`. This kind of thing is why I'm not a huge fan of `mutableConfig`. Any suggestions for things to change here, or should we leave this as-is?